### PR TITLE
Update Node and Java chaincode build status links

### DIFF
--- a/docs/builds/pipeline_status.md
+++ b/docs/builds/pipeline_status.md
@@ -11,18 +11,7 @@ title: CI Pipelines Status
 >
 > [![FCJ GitHub repo](https://img.shields.io/badge/github.com-repo-brightgreen)](https://github.com/hyperledger/fabric-chaincode-java)
 
-- [![FCJ 2.2 status](https://img.shields.io/azure-devops/build/hyperledger/d07733cd-1e69-47ff-9b57-1c8b53bcd14a/39/release-2.2?requestedForFilter=00000002-0000-8888-8000-000000000000)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Java/_build/latest?definitionId=39&branchName=release-2.2&requestedForFilter=00000002-0000-8888-8000-000000000000)
-**Release 2.2 Nightly Builds**
-- [![FCJ 1.4 status](https://img.shields.io/azure-devops/build/hyperledger/d07733cd-1e69-47ff-9b57-1c8b53bcd14a/39/release-1.4?requestedForFilter=00000002-0000-8888-8000-000000000000)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Java/_build/latest?definitionId=39&branchName=release-1.4&requestedForFilter=00000002-0000-8888-8000-000000000000)
-**Release 1.4 Nightly Builds**
-- [![FCJ main status](https://img.shields.io/azure-devops/build/hyperledger/d07733cd-1e69-47ff-9b57-1c8b53bcd14a/39/main?requestedForFilter=00000002-0000-8888-8000-000000000000)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Java/_build/latest?definitionId=39&branchName=main&requestedForFilter=00000002-0000-8888-8000-000000000000)
-**Release main Nightly Builds**
-- [![FCJ 2.2 PR status](https://img.shields.io/azure-devops/build/hyperledger/d07733cd-1e69-47ff-9b57-1c8b53bcd14a/39/release-2.2?requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Java/_build/latest?definitionId=39&branchName=release-2.2&requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)
-**Release 2.2 GitHub Requested Builds**
-- [![FCJ 1.4 PR status](https://img.shields.io/azure-devops/build/hyperledger/d07733cd-1e69-47ff-9b57-1c8b53bcd14a/39/release-1.4?requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Java/_build/latest?definitionId=39&branchName=release-1.4&requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)
-**Release 1.4 GitHub Requested Builds**
-- [![FCJ main PR status](https://img.shields.io/azure-devops/build/hyperledger/d07733cd-1e69-47ff-9b57-1c8b53bcd14a/39/main?requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Java/_build/latest?definitionId=39&branchName=main&requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)
-**Release main GitHub Requested Builds**
+- [![Java chaincode build status](https://github.com/hyperledger/fabric-chaincode-java/actions/workflows/schedule.yml/badge.svg)](https://github.com/hyperledger/fabric-chaincode-java/actions/workflows/schedule.yml) **Build status**
 
 ## Fabric Chaincode Node
 
@@ -33,24 +22,14 @@ title: CI Pipelines Status
 >
 > [![FCN GitHub repo](https://img.shields.io/badge/github.com-repo-brightgreen)](https://github.com/hyperledger/fabric-chaincode-node)
 
-- [![FCN 2.2 status](https://img.shields.io/azure-devops/build/hyperledger/071652b7-a686-427a-a7c9-f9cc6bd4150a/33/release-2.2?requestedForFilter=00000002-0000-8888-8000-000000000000)]((https://dev.azure.com/Hyperledger/Fabric-Chaincode-Node/_build/latest?definitionId=33&branchName=release-2.2&requestedForFilter=00000002-0000-8888-8000-000000000000))
-**Release 2.2 Nightly Builds**
-- [![FCN 1.4 status](https://img.shields.io/azure-devops/build/hyperledger/071652b7-a686-427a-a7c9-f9cc6bd4150a/33/release-1.4?requestedForFilter=00000002-0000-8888-8000-000000000000)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Node/_build/latest?definitionId=33&branchName=release-1.4&requestedForFilter=00000002-0000-8888-8000-000000000000)
-**Release 1.4 Nightly Builds**
-- [![FCN main status](https://img.shields.io/azure-devops/build/hyperledger/071652b7-a686-427a-a7c9-f9cc6bd4150a/33/main?requestedForFilter=00000002-0000-8888-8000-000000000000)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Node/_build/latest?definitionId=33&branchName=main&requestedForFilter=00000002-0000-8888-8000-000000000000)
-**Release main Nightly Builds**
-- [![FCN 2.2 PR status](https://img.shields.io/azure-devops/build/hyperledger/071652b7-a686-427a-a7c9-f9cc6bd4150a/33/release-2.2?requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Node/_build/latest?definitionId=33&branchName=release-2.2&requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)
-**Release 2.2 GitHub Requested Builds**
-- [![FCN 1.4 PR status](https://img.shields.io/azure-devops/build/hyperledger/071652b7-a686-427a-a7c9-f9cc6bd4150a/33/release-1.4?requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Node/_build/latest?definitionId=33&branchName=release-1.4&requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)
-**Release 1.4 GitHub Requested Builds**
-- [![FCN main PR status](https://img.shields.io/azure-devops/build/hyperledger/071652b7-a686-427a-a7c9-f9cc6bd4150a/33/main?requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)](https://dev.azure.com/Hyperledger/Fabric-Chaincode-Node/_build/latest?definitionId=33&branchName=main&requestedForFilter=0c0e01d1-603c-4063-bb80-29b12b0cfdc2)
-**Release main GitHub Requested Builds**
+- [![Node chaincode build status](https://github.com/hyperledger/fabric-chaincode-node/actions/workflows/schedule.yaml/badge.svg)](https://github.com/hyperledger/fabric-chaincode-node/actions/workflows/schedule.yaml) **Build status**
 
 ## Fabric Contract API Go
 
 > [![FCG GitHub repo](https://img.shields.io/badge/github.com-repo-brightgreen)](https://github.com/hyperledger/fabric-contract-api-go)
 
 - [![FCG main status](https://img.shields.io/azure-devops/build/Hyperledger/feaaa88c-b1d7-4033-8dae-9f0230c8cc58/48/main?label=main)](https://dev.azure.com/Hyperledger/Fabric-Contract-API-Go/_build/latest?definitionId=48&branchName=main)
+- [![FCG vulnerability scan](https://github.com/hyperledger/fabric-contract-api-go/actions/workflows/vulnerability-scan.yml/badge.svg)](https://github.com/hyperledger/fabric-contract-api-go/actions/workflows/vulnerability-scan.yml)
 
 
 # SDK Builds


### PR DESCRIPTION
Builds are now run in GitHub Actions instead of Azure Pipelines.